### PR TITLE
Add date picker component to choose a date for an action

### DIFF
--- a/client/src/components/DatePicker.js
+++ b/client/src/components/DatePicker.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import DatePicker from 'react-date-picker';
+
+class ChooseDate extends React.Component {
+  state = {
+    date: new Date(),
+  }
+  
+  onChange = date => this.setState({ date })
+  
+  render() {
+    return (
+      <div className="date-picker">
+      <h4>Choose a date</h4>
+      <DatePicker
+      onChange={this.onChange}
+      value={this.state.date}
+      />
+      </div>
+    )
+  }
+  
+};
+
+export default ChooseDate;


### PR DESCRIPTION
This adds a simple date picker component that allows someone to type in a date (the format of DD/MM or MM/DD defaults to your browser locale) or open a calendar to set the date. This component would be used to enter the date of an action.

Note: We haven't yet written a route for the action item to store in the database, nor the full action item component itself. In theory, this component is different from the calendar.js component, which should show a full calendar with all your items on it...

I was testing on the dashboard to have some place to see it.
![image](https://user-images.githubusercontent.com/4380498/38125855-6122f8a6-33a1-11e8-8100-5058d98ede89.png)

https://www.npmjs.com/package/react-date-picker