### PR TITLE
Make actions date format better

### DIFF
--- a/client/src/components/YourActions.js
+++ b/client/src/components/YourActions.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 // import SummaryGraph from './SummaryGraph';
 import ActionModal from './ActionModal';
 import DatePicker from 'react-date-picker';
+import moment from 'moment';
 
 class YourActions extends Component {
   state = {
@@ -32,7 +33,7 @@ class YourActions extends Component {
             {this.props.actions.map(data => {
               return (
                 <tr key={data._id}>
-                  <td>{data.date}</td>
+                  <td>{moment(data.date).format("MM/DD/YYYY")}</td>
                   <td>{data.description}</td>
                   <td>{data.status}</td>
                   <td>              


### PR DESCRIPTION
This improves the appearance of the date on the actions list to use MM/DD/YYYY instead of a lengthy entry with seconds and all that.

Note:
- This requires `moment` - so we'll need to eventually do `npm i moment --save` into the client and commit it into the package.json file. I did not include this file here because we seem to keep overwriting each other's files and breaking it.
- For simplicity, this just "hardcodes" the format to month/day. It may look weird on machines with DD/MM because the date picker is smart enough to use the locale, but we have other bugs to fix first. :)